### PR TITLE
Add batch fetching for papers and test script

### DIFF
--- a/paper_batch.py
+++ b/paper_batch.py
@@ -1,0 +1,25 @@
+import time
+from typing import List
+
+from fetch_paper import fetch_paper
+
+
+def fetch_papers_from_file(file_path: str = "papers.txt", limit_per_minute: int = 20) -> List[str]:
+    """Fetch all papers listed in the given file respecting the rate limit.
+
+    Each non-empty line in the file should contain a single URL. The function
+    calls :func:`fetch_paper` for every URL and returns the list of paths to
+    the created JSON files. To avoid exceeding the API rate limit it waits
+    ``60 / limit_per_minute`` seconds between calls.
+    """
+    with open(file_path, "r", encoding="utf-8") as f:
+        urls = [line.strip() for line in f if line.strip()]
+
+    delay = 60.0 / limit_per_minute if limit_per_minute else 0
+    paths = []
+
+    for url in urls:
+        paths.append(fetch_paper(url))
+        if delay:
+            time.sleep(delay)
+    return paths

--- a/papers.txt
+++ b/papers.txt
@@ -1,0 +1,2 @@
+https://conf.researchr.org/details/fse-2025/fse-2025-industry-papers/39/Quantifying-the-benefits-of-code-hints-for-refactoring-deprecated-Java-APIs
+https://conf.researchr.org/details/fse-2025/fse-2025-industry-papers/40/Another-fake-url-for-testing

--- a/test_paper_batch.py
+++ b/test_paper_batch.py
@@ -1,0 +1,7 @@
+from paper_batch import fetch_papers_from_file
+
+if __name__ == "__main__":
+    paths = fetch_papers_from_file()
+    print("Zapisano dane w plikach:")
+    for path in paths:
+        print(path)


### PR DESCRIPTION
## Summary
- implement `fetch_papers_from_file` with builtin rate limiting
- add a short example `papers.txt`
- provide simple test script `test_paper_batch.py`

## Testing
- `python3 -m py_compile paper_batch.py test_paper_batch.py`
- `python3 test_paper_batch.py` *(fails: `URLError: <urlopen error Tunnel connection failed: 403 Forbidden>`)*

------
https://chatgpt.com/codex/tasks/task_e_683f561d5464832b9b69ec172f72f873