### PR TITLE
Fix author fields and add affiliation view

### DIFF
--- a/paper_search.py
+++ b/paper_search.py
@@ -47,7 +47,19 @@ def embed_papers(papers_dir: str = "papers") -> None:
         text = _build_text(data)
         response = oa.embeddings.create(input=text, model=EMBEDDING_MODEL)
         vector = response.data[0].embedding
-        payload = data
+        payload = data.copy()
+        authors = data.get("authors")
+        if isinstance(authors, list):
+            formatted = []
+            for a in authors:
+                name = a.get("name")
+                aff = a.get("affiliation")
+                if aff:
+                    formatted.append(f"{name} ({aff})")
+                else:
+                    formatted.append(name)
+            payload["authors"] = "; ".join(filter(None, formatted))
+        payload["presentation"] = data.get("presentation")
         points.append(rest.PointStruct(id=idx, vector=vector, payload=payload))
 
     if points:

--- a/prepare_affiliations.py
+++ b/prepare_affiliations.py
@@ -1,0 +1,29 @@
+import glob
+import json
+import os
+from typing import Dict, List
+
+
+def prepare_affiliation_list(papers_dir: str = "papers", output_file: str = "affiliations.json") -> str:
+    """Create a mapping of affiliation -> list of paper titles."""
+    affiliations: Dict[str, List[str]] = {}
+    for path in glob.glob(os.path.join(papers_dir, "*.json")):
+        with open(path, "r", encoding="utf-8") as f:
+            try:
+                data = json.load(f)
+            except json.JSONDecodeError:
+                continue
+        title = data.get("title")
+        for author in data.get("authors", []):
+            aff = author.get("affiliation") or "Unknown"
+            affiliations.setdefault(aff, [])
+            if title and title not in affiliations[aff]:
+                affiliations[aff].append(title)
+    with open(output_file, "w", encoding="utf-8") as f:
+        json.dump(affiliations, f, ensure_ascii=False, indent=2)
+    return output_file
+
+
+if __name__ == "__main__":
+    path = prepare_affiliation_list()
+    print(f"Affiliation list saved to {path}")

--- a/webapp.py
+++ b/webapp.py
@@ -19,6 +19,7 @@ HTML_SEARCH = """
         <li class=\"nav-item\"><a class=\"nav-link active\" href=\"/\">Search</a></li>
         <li class=\"nav-item\"><a class=\"nav-link\" href=\"/summary\">Summary</a></li>
         <li class=\"nav-item\"><a class=\"nav-link\" href=\"/similar\">Similarities</a></li>
+        <li class=\"nav-item\"><a class=\"nav-link\" href=\"/affiliations\">Affiliations</a></li>
       </ul>
       <form method=\"get\" class=\"mb-4\">
         <div class=\"input-group\">
@@ -56,6 +57,7 @@ HTML_SUMMARY = """
         <li class=\"nav-item\"><a class=\"nav-link\" href=\"/\">Search</a></li>
         <li class=\"nav-item\"><a class=\"nav-link active\" href=\"/summary\">Summary</a></li>
         <li class=\"nav-item\"><a class=\"nav-link\" href=\"/similar\">Similarities</a></li>
+        <li class=\"nav-item\"><a class=\"nav-link\" href=\"/affiliations\">Affiliations</a></li>
       </ul>
       <div class="markdown-body">{{ summary|safe }}</div>
     </div>
@@ -80,6 +82,7 @@ HTML_SIMILAR = """
         <li class=\"nav-item\"><a class=\"nav-link\" href=\"/\">Search</a></li>
         <li class=\"nav-item\"><a class=\"nav-link\" href=\"/summary\">Summary</a></li>
         <li class=\"nav-item\"><a class=\"nav-link active\" href=\"/similar\">Similarities</a></li>
+        <li class=\"nav-item\"><a class=\"nav-link\" href=\"/affiliations\">Affiliations</a></li>
       </ul>
       <canvas id=\"scatter\" width=\"600\" height=\"400\"></canvas>
       <script>
@@ -105,6 +108,39 @@ HTML_SIMILAR = """
           }
         });
       </script>
+    </div>
+  </body>
+</html>
+"""
+
+HTML_AFFILIATIONS = """
+<!doctype html>
+<html lang=\"en\">
+  <head>
+    <meta charset=\"utf-8\">
+    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+    <title>ConfAdvisor - Affiliations</title>
+    <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css\">
+  </head>
+  <body>
+    <div class=\"container py-4\">
+      <h1 class=\"mb-4\">ConfAdvisor</h1>
+      <ul class=\"nav nav-tabs mb-4\">
+        <li class=\"nav-item\"><a class=\"nav-link\" href=\"/\">Search</a></li>
+        <li class=\"nav-item\"><a class=\"nav-link\" href=\"/summary\">Summary</a></li>
+        <li class=\"nav-item\"><a class=\"nav-link\" href=\"/similar\">Similarities</a></li>
+        <li class=\"nav-item\"><a class=\"nav-link active\" href=\"/affiliations\">Affiliations</a></li>
+      </ul>
+      {% for aff, titles in data.items() %}
+      <div class=\"mb-3\">
+        <h5>{{ aff }}</h5>
+        <ul>
+          {% for title in titles %}
+          <li>{{ title }}</li>
+          {% endfor %}
+        </ul>
+      </div>
+      {% endfor %}
     </div>
   </body>
 </html>
@@ -140,6 +176,16 @@ def similar():
     except FileNotFoundError:
         data = []
     return render_template_string(HTML_SIMILAR, data=json.dumps(data))
+
+
+@app.route("/affiliations")
+def affiliations():
+    try:
+        with open("affiliations.json", "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        data = {}
+    return render_template_string(HTML_AFFILIATIONS, data=data)
 
 if __name__ == "__main__":
     app.run(debug=True)


### PR DESCRIPTION
## Summary
- include authors and presentation data when uploading papers to Qdrant
- generate list of papers grouped by affiliation
- expose affiliation list in new webapp tab

## Testing
- `python3 test_fetch_paper.py`
- `python3 test_analyze_paper.py` *(fails: No such file or directory 'key.txt')*
- `python3 test_paper_batch.py` *(interrupted: KeyboardInterrupt)*
- `python3 test_summarize_papers.py` *(fails: FileNotFoundError: 'key.txt')*


------
https://chatgpt.com/codex/tasks/task_e_6846bf145f2c832b90f4a0bf16db42c7