### PR TITLE
Refactor Flask templates and JS search

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ python webapp.py
 ```
 
 The application connects to a local Qdrant instance and requires `key.txt` with an OpenAI API key.
+Results on the search page are fetched via JavaScript from `/api/search`.
+Templates live in the `templates/` directory and client scripts in `static/`.
 
 ## Preparing visualization data
 

--- a/static/search.js
+++ b/static/search.js
@@ -1,0 +1,25 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('searchForm');
+  const results = document.getElementById('results');
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const q = document.getElementById('query').value;
+    results.innerHTML = '';
+    if (!q.trim()) return;
+    const resp = await fetch('/api/search?q=' + encodeURIComponent(q));
+    const data = await resp.json();
+    data.forEach(paper => {
+      const card = document.createElement('div');
+      card.className = 'card mb-3';
+      const body = document.createElement('div');
+      body.className = 'card-body';
+      Object.entries(paper).forEach(([k, v]) => {
+        const p = document.createElement('p');
+        p.innerHTML = `<strong>${k}:</strong> ${v}`;
+        body.appendChild(p);
+      });
+      card.appendChild(body);
+      results.appendChild(card);
+    });
+  });
+});

--- a/templates/affiliations.html
+++ b/templates/affiliations.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block title %} - Affiliations{% endblock %}
+{% block content %}
+<form method="get" class="mb-4">
+  <div class="input-group">
+    <input type="text" name="q" class="form-control" placeholder="Search affiliation" value="{{ query }}">
+    <button class="btn btn-primary" type="submit">Search</button>
+  </div>
+</form>
+{% for aff, titles in data.items() %}
+<div class="mb-3">
+  <h5>{{ aff }}</h5>
+  <ul>
+  {% for title in titles %}
+    <li>{{ title }}</li>
+  {% endfor %}
+  </ul>
+</div>
+{% endfor %}
+{% endblock %}

--- a/templates/authors.html
+++ b/templates/authors.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% block title %} - Authors{% endblock %}
+{% block content %}
+<form method="get" class="mb-4">
+  <div class="input-group">
+    <input type="text" name="q" class="form-control" placeholder="Search author" value="{{ query }}">
+    <button class="btn btn-primary" type="submit">Search</button>
+  </div>
+</form>
+{% for name, info in data.items() %}
+<div class="mb-3">
+  <h5>{{ name }}</h5>
+  <p><em>{{ info.affiliation }}</em></p>
+  <ul>
+  {% for title in info.papers %}
+    <li>{{ title }}</li>
+  {% endfor %}
+  </ul>
+</div>
+{% endfor %}
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>ConfAdvisor{% block title %}{% endblock %}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+    {% block head %}{% endblock %}
+  </head>
+  <body>
+    <div class="container py-4">
+      <h1 class="mb-4">ConfAdvisor</h1>
+      <ul class="nav nav-tabs mb-4">
+        <li class="nav-item"><a class="nav-link{% if active == 'search' %} active{% endif %}" href="/">Search</a></li>
+        <li class="nav-item"><a class="nav-link{% if active == 'summary' %} active{% endif %}" href="/summary">Summary</a></li>
+        <li class="nav-item"><a class="nav-link{% if active == 'similar' %} active{% endif %}" href="/similar">Similarities</a></li>
+        <li class="nav-item"><a class="nav-link{% if active == 'affiliations' %} active{% endif %}" href="/affiliations">Affiliations</a></li>
+        <li class="nav-item"><a class="nav-link{% if active == 'authors' %} active{% endif %}" href="/authors">Authors</a></li>
+      </ul>
+      {% block content %}{% endblock %}
+    </div>
+  </body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% block title %} - Search{% endblock %}
+{% block head %}
+<script src="{{ url_for('static', filename='search.js') }}"></script>
+{% endblock %}
+{% block content %}
+<form id="searchForm" class="mb-4">
+  <div class="input-group">
+    <input type="text" id="query" class="form-control" placeholder="Search">
+    <button class="btn btn-primary" type="submit">Search</button>
+  </div>
+</form>
+<div id="results"></div>
+{% endblock %}

--- a/templates/similar.html
+++ b/templates/similar.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% block title %} - Similarities{% endblock %}
+{% block head %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+{% endblock %}
+{% block content %}
+<canvas id="scatter" width="600" height="400"></canvas>
+<script>
+const data = {{ data | safe }};
+const chartData = {
+  datasets: [{
+    label: 'papers',
+    data: data,
+    parsing: { xAxisKey: 'x', yAxisKey: 'y' }
+  }]
+};
+new Chart(document.getElementById('scatter'), {
+  type: 'scatter',
+  data: chartData,
+  options: {
+    plugins: {
+      tooltip: {
+        callbacks: { label: ctx => ctx.raw.title }
+      }
+    }
+  }
+});
+</script>
+{% endblock %}

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block title %} - Summary{% endblock %}
+{% block content %}
+<div class="markdown-body">{{ summary|safe }}</div>
+{% endblock %}

--- a/webapp.py
+++ b/webapp.py
@@ -1,203 +1,22 @@
-from flask import Flask, request, render_template_string
+from flask import Flask, request, jsonify, render_template
 import markdown
 import json
 from paper_search import search_by_embedding, list_all_papers
-
-HTML_SEARCH = """
-<!doctype html>
-<html lang=\"en\">
-  <head>
-    <meta charset=\"utf-8\">
-    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
-    <title>ConfAdvisor</title>
-    <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css\">
-  </head>
-  <body>
-    <div class=\"container py-4\">
-      <h1 class=\"mb-4\">ConfAdvisor</h1>
-      <ul class=\"nav nav-tabs mb-4\">
-        <li class=\"nav-item\"><a class=\"nav-link active\" href=\"/\">Search</a></li>
-        <li class=\"nav-item\"><a class=\"nav-link\" href=\"/summary\">Summary</a></li>
-        <li class=\"nav-item\"><a class=\"nav-link\" href=\"/similar\">Similarities</a></li>
-        <li class=\"nav-item\"><a class=\"nav-link\" href=\"/affiliations\">Affiliations</a></li>
-        <li class=\"nav-item\"><a class=\"nav-link\" href=\"/authors\">Authors</a></li>
-      </ul>
-      <form method=\"get\" class=\"mb-4\">
-        <div class=\"input-group\">
-          <input type=\"text\" name=\"q\" class=\"form-control\" placeholder=\"Search\" value=\"{{ query }}\">
-          <button class=\"btn btn-primary\" type=\"submit\">Search</button>
-        </div>
-      </form>
-      {% for paper in papers %}
-      <div class=\"card mb-3\">
-        <div class=\"card-body\">
-        {% for key, value in paper.items() %}
-          <p><strong>{{ key }}:</strong> {{ value }}</p>
-        {% endfor %}
-        </div>
-      </div>
-      {% endfor %}
-    </div>
-  </body>
-</html>
-"""
-
-HTML_SUMMARY = """
-<!doctype html>
-<html lang=\"en\">
-  <head>
-    <meta charset=\"utf-8\">
-    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
-    <title>ConfAdvisor - Summary</title>
-    <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css\">
-  </head>
-  <body>
-    <div class=\"container py-4\">
-      <h1 class=\"mb-4\">ConfAdvisor</h1>
-      <ul class=\"nav nav-tabs mb-4\">
-        <li class=\"nav-item\"><a class=\"nav-link\" href=\"/\">Search</a></li>
-        <li class=\"nav-item\"><a class=\"nav-link active\" href=\"/summary\">Summary</a></li>
-        <li class=\"nav-item\"><a class=\"nav-link\" href=\"/similar\">Similarities</a></li>
-        <li class=\"nav-item\"><a class=\"nav-link\" href=\"/affiliations\">Affiliations</a></li>
-        <li class=\"nav-item\"><a class=\"nav-link\" href=\"/authors\">Authors</a></li>
-      </ul>
-      <div class="markdown-body">{{ summary|safe }}</div>
-    </div>
-  </body>
-</html>
-"""
-
-HTML_SIMILAR = """
-<!doctype html>
-<html lang=\"en\">
-  <head>
-    <meta charset=\"utf-8\">
-    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
-    <title>ConfAdvisor - Similarities</title>
-    <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css\">
-    <script src=\"https://cdn.jsdelivr.net/npm/chart.js\"></script>
-  </head>
-  <body>
-    <div class=\"container py-4\">
-      <h1 class=\"mb-4\">ConfAdvisor</h1>
-      <ul class=\"nav nav-tabs mb-4\">
-        <li class=\"nav-item\"><a class=\"nav-link\" href=\"/\">Search</a></li>
-        <li class=\"nav-item\"><a class=\"nav-link\" href=\"/summary\">Summary</a></li>
-        <li class=\"nav-item\"><a class=\"nav-link active\" href=\"/similar\">Similarities</a></li>
-        <li class=\"nav-item\"><a class=\"nav-link\" href=\"/affiliations\">Affiliations</a></li>
-        <li class=\"nav-item\"><a class=\"nav-link\" href=\"/authors\">Authors</a></li>
-      </ul>
-      <canvas id=\"scatter\" width=\"600\" height=\"400\"></canvas>
-      <script>
-        const data = {{ data | safe }};
-        const chartData = {
-          datasets: [{
-            label: 'papers',
-            data: data,
-            parsing: { xAxisKey: 'x', yAxisKey: 'y' }
-          }]
-        };
-        new Chart(document.getElementById('scatter'), {
-          type: 'scatter',
-          data: chartData,
-          options: {
-            plugins: {
-              tooltip: {
-                callbacks: {
-                  label: ctx => ctx.raw.title
-                }
-              }
-            }
-          }
-        });
-      </script>
-    </div>
-  </body>
-</html>
-"""
-
-HTML_AFFILIATIONS = """
-<!doctype html>
-<html lang=\"en\">
-  <head>
-    <meta charset=\"utf-8\">
-    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
-    <title>ConfAdvisor - Affiliations</title>
-    <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css\">
-  </head>
-  <body>
-    <div class=\"container py-4\">
-      <h1 class=\"mb-4\">ConfAdvisor</h1>
-      <ul class=\"nav nav-tabs mb-4\">
-        <li class=\"nav-item\"><a class=\"nav-link\" href=\"/\">Search</a></li>
-        <li class=\"nav-item\"><a class=\"nav-link\" href=\"/summary\">Summary</a></li>
-        <li class=\"nav-item\"><a class=\"nav-link\" href=\"/similar\">Similarities</a></li>
-        <li class=\"nav-item\"><a class=\"nav-link active\" href=\"/affiliations\">Affiliations</a></li>
-        <li class=\"nav-item\"><a class=\"nav-link\" href=\"/authors\">Authors</a></li>
-      </ul>
-      <form method=\"get\" class=\"mb-4\">\n        <div class=\"input-group\">\n          <input type=\"text\" name=\"q\" class=\"form-control\" placeholder=\"Search affiliation\" value=\"{{ query }}\">\n          <button class=\"btn btn-primary\" type=\"submit\">Search</button>\n        </div>\n      </form>
-      {% for aff, titles in data.items() %}
-      <div class=\"mb-3\">
-        <h5>{{ aff }}</h5>
-        <ul>
-          {% for title in titles %}
-          <li>{{ title }}</li>
-          {% endfor %}
-        </ul>
-      </div>
-      {% endfor %}
-    </div>
-  </body>
-</html>
-"""
-
-HTML_AUTHORS = """
-<!doctype html>
-<html lang=\"en\">
-  <head>
-    <meta charset=\"utf-8\">
-    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
-    <title>ConfAdvisor - Authors</title>
-    <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css\">
-  </head>
-  <body>
-    <div class=\"container py-4\">
-      <h1 class=\"mb-4\">ConfAdvisor</h1>
-      <ul class=\"nav nav-tabs mb-4\">
-        <li class=\"nav-item\"><a class=\"nav-link\" href=\"/\">Search</a></li>
-        <li class=\"nav-item\"><a class=\"nav-link\" href=\"/summary\">Summary</a></li>
-        <li class=\"nav-item\"><a class=\"nav-link\" href=\"/similar\">Similarities</a></li>
-        <li class=\"nav-item\"><a class=\"nav-link\" href=\"/affiliations\">Affiliations</a></li>
-        <li class=\"nav-item\"><a class=\"nav-link active\" href=\"/authors\">Authors</a></li>
-      </ul>
-      <form method=\"get\" class=\"mb-4\">\n        <div class=\"input-group\">\n          <input type=\"text\" name=\"q\" class=\"form-control\" placeholder=\"Search author\" value=\"{{ query }}\">\n          <button class=\"btn btn-primary\" type=\"submit\">Search</button>\n        </div>\n      </form>
-      {% for name, info in data.items() %}
-      <div class=\"mb-3\">
-        <h5>{{ name }}</h5>
-        <p><em>{{ info.affiliation }}</em></p>
-        <ul>
-          {% for title in info.papers %}
-          <li>{{ title }}</li>
-          {% endfor %}
-        </ul>
-      </div>
-      {% endfor %}
-    </div>
-  </body>
-</html>
-"""
 
 app = Flask(__name__)
 
 @app.route("/")
 def index():
+    return render_template("index.html", active="search")
+
+@app.route("/api/search")
+def api_search():
     query = request.args.get("q", "").strip()
     if query:
         papers = [payload for _, payload in search_by_embedding(query, limit=50)]
     else:
         papers = list_all_papers()
-    return render_template_string(HTML_SEARCH, papers=papers, query=query)
-
+    return jsonify(papers)
 
 @app.route("/summary")
 def summary():
@@ -206,8 +25,7 @@ def summary():
             content = markdown.markdown(f.read())
     except FileNotFoundError:
         content = "Summary file not found."
-    return render_template_string(HTML_SUMMARY, summary=content)
-
+    return render_template("summary.html", summary=content, active="summary")
 
 @app.route("/similar")
 def similar():
@@ -216,8 +34,7 @@ def similar():
             data = json.load(f)
     except FileNotFoundError:
         data = []
-    return render_template_string(HTML_SIMILAR, data=json.dumps(data))
-
+    return render_template("similar.html", data=json.dumps(data), active="similar")
 
 @app.route("/affiliations")
 def affiliations():
@@ -229,8 +46,7 @@ def affiliations():
         data = {}
     if query:
         data = {k: v for k, v in data.items() if query in k.lower()}
-    return render_template_string(HTML_AFFILIATIONS, data=data, query=query)
-
+    return render_template("affiliations.html", data=data, query=query, active="affiliations")
 
 @app.route("/authors")
 def authors():
@@ -242,7 +58,7 @@ def authors():
         data = {}
     if query:
         data = {k: v for k, v in data.items() if query in k.lower()}
-    return render_template_string(HTML_AUTHORS, data=data, query=query)
+    return render_template("authors.html", data=data, query=query, active="authors")
 
 if __name__ == "__main__":
     app.run(debug=True)


### PR DESCRIPTION
## Summary
- move HTML to Jinja templates
- add `static/search.js` for client-side search via `/api/search`
- update Flask app to use templates and new API route
- document JS-based search in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6846fd288a5c832b97891dd596933f81