### PR TITLE
Fix search template

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -4,11 +4,21 @@
 <script src="{{ url_for('static', filename='search.js') }}"></script>
 {% endblock %}
 {% block content %}
-<form id="searchForm" class="mb-4">
+<form id="searchForm" method="get" class="mb-4">
   <div class="input-group">
-    <input type="text" id="query" class="form-control" placeholder="Search">
+    <input type="text" name="q" id="query" class="form-control" placeholder="Search" value="{{ query }}">
     <button class="btn btn-primary" type="submit">Search</button>
   </div>
 </form>
-<div id="results"></div>
+<div id="results">
+  {% for paper in papers %}
+  <div class="card mb-3">
+    <div class="card-body">
+      {% for key, value in paper.items() %}
+      <p><strong>{{ key }}:</strong> {{ value }}</p>
+      {% endfor %}
+    </div>
+  </div>
+  {% endfor %}
+</div>
 {% endblock %}

--- a/webapp.py
+++ b/webapp.py
@@ -7,7 +7,12 @@ app = Flask(__name__)
 
 @app.route("/")
 def index():
-    return render_template("index.html", active="search")
+    query = request.args.get("q", "").strip()
+    if query:
+        papers = [payload for _, payload in search_by_embedding(query, limit=50)]
+    else:
+        papers = list_all_papers()
+    return render_template("index.html", papers=papers, query=query, active="search")
 
 @app.route("/api/search")
 def api_search():


### PR DESCRIPTION
## Summary
- render search results in `index.html`
- update Flask route to pass papers and current query

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError for external dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684703b59a94832ba0368c356446da26