### PR TITLE
Add keyword search UI

### DIFF
--- a/static/keywords.js
+++ b/static/keywords.js
@@ -1,0 +1,42 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const boxes = document.querySelectorAll('.kw-box');
+  const modeSelect = document.getElementById('mode');
+  const clearBtn = document.getElementById('clearKeywords');
+  const results = document.getElementById('results');
+
+  async function fetchResults() {
+    const selected = Array.from(boxes)
+      .filter(b => b.checked)
+      .map(b => b.value);
+    const params = new URLSearchParams();
+    selected.forEach(kw => params.append('kw', kw));
+    params.set('mode', modeSelect.value);
+    if (selected.length === 0) {
+      results.innerHTML = '';
+      return;
+    }
+    const resp = await fetch('/api/keywords?' + params.toString());
+    const data = await resp.json();
+    results.innerHTML = '';
+    data.forEach(paper => {
+      const card = document.createElement('div');
+      card.className = 'card mb-3';
+      const body = document.createElement('div');
+      body.className = 'card-body';
+      Object.entries(paper).forEach(([k, v]) => {
+        const p = document.createElement('p');
+        p.innerHTML = `<strong>${k}:</strong> ${v}`;
+        body.appendChild(p);
+      });
+      card.appendChild(body);
+      results.appendChild(card);
+    });
+  }
+
+  boxes.forEach(b => b.addEventListener('change', fetchResults));
+  modeSelect.addEventListener('change', fetchResults);
+  clearBtn.addEventListener('click', () => {
+    boxes.forEach(b => { b.checked = false; });
+    fetchResults();
+  });
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,6 +16,7 @@
         <li class="nav-item"><a class="nav-link{% if active == 'similar' %} active{% endif %}" href="/similar">Similarities</a></li>
         <li class="nav-item"><a class="nav-link{% if active == 'affiliations' %} active{% endif %}" href="/affiliations">Affiliations</a></li>
         <li class="nav-item"><a class="nav-link{% if active == 'authors' %} active{% endif %}" href="/authors">Authors</a></li>
+        <li class="nav-item"><a class="nav-link{% if active == 'keywords' %} active{% endif %}" href="/keywords">Keywords</a></li>
       </ul>
       {% block content %}{% endblock %}
     </div>

--- a/templates/keywords.html
+++ b/templates/keywords.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+{% block title %} - Keyword Search{% endblock %}
+{% block head %}
+<script src="{{ url_for('static', filename='keywords.js') }}"></script>
+{% endblock %}
+{% block content %}
+<div class="mb-3">
+  <div class="mb-2">
+    <label for="mode" class="form-label">Match mode</label>
+    <select id="mode" class="form-select w-auto d-inline-block">
+      <option value="AND"{% if mode == 'AND' %} selected{% endif %}>AND</option>
+      <option value="OR"{% if mode == 'OR' %} selected{% endif %}>OR</option>
+    </select>
+    <button id="clearKeywords" class="btn btn-secondary btn-sm ms-2">Clear</button>
+  </div>
+  <div id="keywordList" class="mb-3">
+    {% for kw in keywords %}
+    <div class="form-check form-check-inline">
+      <input class="form-check-input kw-box" type="checkbox" value="{{ kw }}" id="kw{{ loop.index }}"{% if kw in selected %} checked{% endif %}>
+      <label class="form-check-label" for="kw{{ loop.index }}">{{ kw }}</label>
+    </div>
+    {% endfor %}
+  </div>
+</div>
+<div id="results">
+  {% for paper in papers %}
+  <div class="card mb-3">
+    <div class="card-body">
+      {% for key, value in paper.items() %}
+      <p><strong>{{ key }}:</strong> {{ value }}</p>
+      {% endfor %}
+    </div>
+  </div>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/webapp.py
+++ b/webapp.py
@@ -1,7 +1,12 @@
 from flask import Flask, request, jsonify, render_template
 import markdown
 import json
-from paper_search import search_by_embedding, list_all_papers
+from paper_search import (
+    search_by_embedding,
+    list_all_papers,
+    list_all_keywords,
+    search_by_keywords,
+)
 
 app = Flask(__name__)
 
@@ -64,6 +69,30 @@ def authors():
     if query:
         data = {k: v for k, v in data.items() if query in k.lower()}
     return render_template("authors.html", data=data, query=query, active="authors")
+
+
+@app.route("/keywords")
+def keywords_page():
+    selected = request.args.getlist("kw")
+    mode = request.args.get("mode", "AND").upper()
+    keywords = list_all_keywords()
+    papers = search_by_keywords(selected, mode, limit=50) if selected else []
+    return render_template(
+        "keywords.html",
+        keywords=keywords,
+        papers=papers,
+        selected=selected,
+        mode=mode,
+        active="keywords",
+    )
+
+
+@app.route("/api/keywords")
+def api_keywords():
+    selected = request.args.getlist("kw")
+    mode = request.args.get("mode", "AND").upper()
+    papers = search_by_keywords(selected, mode, limit=50) if selected else []
+    return jsonify(papers)
 
 if __name__ == "__main__":
     app.run(debug=True)


### PR DESCRIPTION
## Summary
- list available keywords from stored papers
- implement keyword-based search with AND/OR logic
- add `/keywords` view and API endpoint
- create front-end for keyword search with checkboxes and clear button
- link new view in navigation

## Testing
- `python -m py_compile webapp.py paper_search.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684708e39338832ba113f9a7fa33d045