### PR TITLE
Sort papers by presentation time

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,31 @@
+import re
+from datetime import datetime
+from typing import Optional, List, Dict
+
+# Regular expression to capture date and start time, e.g. "Mon 23 Jun 2025 11:40"
+_PRES_RE = re.compile(r"[A-Za-z]{3} \d{1,2} [A-Za-z]{3} \d{4} \d{2}:\d{2}")
+
+
+def parse_presentation_datetime(presentation: str) -> Optional[datetime]:
+    """Parse presentation string into datetime.
+
+    Returns None if parsing fails.
+    """
+    if not presentation:
+        return None
+    match = _PRES_RE.search(presentation)
+    if not match:
+        return None
+    try:
+        return datetime.strptime(match.group(0), "%a %d %b %Y %H:%M")
+    except ValueError:
+        return None
+
+
+def sort_by_presentation(papers: List[Dict]) -> List[Dict]:
+    """Return papers sorted by presentation datetime."""
+    return sorted(
+        papers,
+        key=lambda p: parse_presentation_datetime(p.get("presentation", ""))
+        or datetime.max,
+    )

--- a/webapp.py
+++ b/webapp.py
@@ -7,6 +7,7 @@ from paper_search import (
     list_all_keywords,
     search_by_keywords,
 )
+from utils import sort_by_presentation
 
 app = Flask(__name__)
 
@@ -17,6 +18,7 @@ def index():
         papers = [payload for _, payload in search_by_embedding(query, limit=50)]
     else:
         papers = list_all_papers()
+    papers = sort_by_presentation(papers)
     return render_template("index.html", papers=papers, query=query, active="search")
 
 @app.route("/api/search")
@@ -26,6 +28,7 @@ def api_search():
         papers = [payload for _, payload in search_by_embedding(query, limit=50)]
     else:
         papers = list_all_papers()
+    papers = sort_by_presentation(papers)
     return jsonify(papers)
 
 @app.route("/summary")
@@ -77,6 +80,7 @@ def keywords_page():
     mode = request.args.get("mode", "AND").upper()
     keywords = list_all_keywords()
     papers = search_by_keywords(selected, mode, limit=50) if selected else []
+    papers = sort_by_presentation(papers)
     return render_template(
         "keywords.html",
         keywords=keywords,
@@ -92,6 +96,7 @@ def api_keywords():
     selected = request.args.getlist("kw")
     mode = request.args.get("mode", "AND").upper()
     papers = search_by_keywords(selected, mode, limit=50) if selected else []
+    papers = sort_by_presentation(papers)
     return jsonify(papers)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `utils.py` with parsing & sorting helpers
- sort papers by presentation time on main page
- sort search & keyword results by presentation time

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684710d4fee8832b8b1154146518c8eb