### PR TITLE
Add TL;DR view for quick paper summaries

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -13,6 +13,7 @@
       <ul class="nav nav-tabs mb-4">
         <li class="nav-item"><a class="nav-link{% if active == 'search' %} active{% endif %}" href="/">Search</a></li>
         <li class="nav-item"><a class="nav-link{% if active == 'summary' %} active{% endif %}" href="/summary">Summary</a></li>
+        <li class="nav-item"><a class="nav-link{% if active == 'tldr' %} active{% endif %}" href="/tldr">TL;DR</a></li>
         <li class="nav-item"><a class="nav-link{% if active == 'similar' %} active{% endif %}" href="/similar">Similarities</a></li>
         <li class="nav-item"><a class="nav-link{% if active == 'affiliations' %} active{% endif %}" href="/affiliations">Affiliations</a></li>
         <li class="nav-item"><a class="nav-link{% if active == 'authors' %} active{% endif %}" href="/authors">Authors</a></li>

--- a/templates/tldr.html
+++ b/templates/tldr.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% block title %} - TL;DR{% endblock %}
+{% block content %}
+<form id="searchForm" method="get" class="mb-4">
+  <div class="input-group">
+    <input type="text" name="q" id="query" class="form-control" placeholder="Search" value="{{ query }}">
+    <button class="btn btn-primary" type="submit">Search</button>
+  </div>
+</form>
+{% for paper in papers %}
+<div class="mb-4">
+  <h5>{{ paper.title }}</h5>
+  {% if paper.authors %}
+  <p><em>{{ paper.authors }}</em></p>
+  {% endif %}
+  {% if paper.explanation %}
+  <p>{{ paper.explanation }}</p>
+  {% else %}
+  <p><em>No explanation available.</em></p>
+  {% endif %}
+</div>
+{% endfor %}
+{% endblock %}

--- a/webapp.py
+++ b/webapp.py
@@ -40,6 +40,29 @@ def summary():
         content = "Summary file not found."
     return render_template("summary.html", summary=content, active="summary")
 
+
+@app.route("/tldr")
+def tldr_view():
+    query = request.args.get("q", "").strip()
+    if query:
+        papers = [payload for _, payload in search_by_embedding(query, limit=50)]
+    else:
+        papers = list_all_papers()
+    papers = sort_by_presentation(papers)
+
+    for p in papers:
+        if "explanation" not in p:
+            p["explanation"] = p.get("explanataion")
+        authors = p.get("authors")
+        if isinstance(authors, list):
+            names = []
+            for a in authors:
+                if isinstance(a, dict) and a.get("name"):
+                    names.append(a["name"])
+            p["authors"] = ", ".join(names)
+
+    return render_template("tldr.html", papers=papers, query=query, active="tldr")
+
 @app.route("/similar")
 def similar():
     try:


### PR DESCRIPTION
## Summary
- link to new TL;DR tab
- implement `/tldr` route showing title, authors and explanation
- add template for TL;DR view

## Testing
- `python -m py_compile webapp.py`

------
https://chatgpt.com/codex/tasks/task_e_684720f34014832bbf3d1095d314e2dd