### PR TITLE
Add dark/light theme toggle

### DIFF
--- a/static/theme.js
+++ b/static/theme.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.getElementById('themeToggle');
+  if (!toggle) return;
+  function updateText(theme) {
+    toggle.textContent = theme === 'dark' ? 'Light mode' : 'Dark mode';
+  }
+  let theme = document.documentElement.getAttribute('data-bs-theme') || 'light';
+  updateText(theme);
+  toggle.addEventListener('click', () => {
+    theme = theme === 'dark' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-bs-theme', theme);
+    localStorage.setItem('theme', theme);
+    updateText(theme);
+  });
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,12 +4,20 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>ConfAdvisor{% block title %}{% endblock %}</title>
+    <script>
+      const storedTheme = localStorage.getItem('theme') || 'light';
+      document.documentElement.setAttribute('data-bs-theme', storedTheme);
+    </script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+    <script src="{{ url_for('static', filename='theme.js') }}"></script>
     {% block head %}{% endblock %}
   </head>
   <body>
     <div class="container py-4">
-      <h1 class="mb-4">ConfAdvisor</h1>
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <h1 class="mb-0">ConfAdvisor</h1>
+        <button id="themeToggle" class="btn btn-outline-secondary btn-sm">Dark mode</button>
+      </div>
       <ul class="nav nav-tabs mb-4">
         <li class="nav-item"><a class="nav-link{% if active == 'search' %} active{% endif %}" href="/">Search</a></li>
         <li class="nav-item"><a class="nav-link{% if active == 'summary' %} active{% endif %}" href="/summary">Summary</a></li>


### PR DESCRIPTION
## Summary
- support light/dark theme selection across the app
- show toggle button in the header

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6847284e9c5c832baa1b159ad61d0f54